### PR TITLE
updated link to Laurens van der Maaten's home page

### DIFF
--- a/sklearn/manifold/t_sne.py
+++ b/sklearn/manifold/t_sne.py
@@ -614,7 +614,7 @@ class TSNE(BaseEstimator):
         Using t-SNE. Journal of Machine Learning Research 9:2579-2605, 2008.
 
     [2] van der Maaten, L.J.P. t-Distributed Stochastic Neighbor Embedding
-        http://homepage.tudelft.nl/19j49/t-SNE.html
+        https://lvdmaaten.github.io/tsne/
 
     [3] L.J.P. van der Maaten. Accelerating t-SNE using Tree-Based Algorithms.
         Journal of Machine Learning Research 15(Oct):3221-3245, 2014.


### PR DESCRIPTION
The references section of TSNE class documentation contained broken link to van der Maaten's home page (that has moved to GitHub).
The home page contains FAQ, examples and other resources.

#### Reference Issues/PRs
Broken link in Reference [2] of TSNE class documentation.

#### What does this implement/fix? Explain your changes.
Updates link in the References section of TSNE documentation.

#### Any other comments?
None


